### PR TITLE
 US34680 Update Go database example to return empty array instead of null

### DIFF
--- a/go-hello-world-service-5/internal/datastore/cockroach.go
+++ b/go-hello-world-service-5/internal/datastore/cockroach.go
@@ -151,6 +151,12 @@ func (c *Cockroach) GetItems(ctx context.Context, id string) (openapi.ImplRespon
 		}
 		list = append(list, i)
 	}
+	if len(list) == 0 {
+		return openapi.ImplResponse{
+			Code: 200,
+			Body: make([]string, 0),
+		}, nil
+	}
 	return openapi.ImplResponse{
 		Code: 200,
 		Body: list,
@@ -241,6 +247,12 @@ func (c *Cockroach) GetLanguages(ctx context.Context) (openapi.ImplResponse, err
 			return openapi.ImplResponse{}, err
 		}
 		list = append(list, i)
+	}
+	if len(list) == 0 {
+		return openapi.ImplResponse{
+			Code: 200,
+			Body: make([]string, 0),
+		}, nil
 	}
 	return openapi.ImplResponse{
 		Code: 200,

--- a/go-hello-world-service-6/internal/datastore/cockroach.go
+++ b/go-hello-world-service-6/internal/datastore/cockroach.go
@@ -151,6 +151,12 @@ func (c *Cockroach) GetItems(ctx context.Context, id string) (openapi.ImplRespon
 		}
 		list = append(list, i)
 	}
+	if len(list) == 0 {
+		return openapi.ImplResponse{
+			Code: 200,
+			Body: make([]string, 0),
+		}, nil
+	}
 	return openapi.ImplResponse{
 		Code: 200,
 		Body: list,
@@ -241,6 +247,12 @@ func (c *Cockroach) GetLanguages(ctx context.Context) (openapi.ImplResponse, err
 			return openapi.ImplResponse{}, err
 		}
 		list = append(list, i)
+	}
+	if len(list) == 0 {
+		return openapi.ImplResponse{
+			Code: 200,
+			Body: make([]string, 0),
+		}, nil
 	}
 	return openapi.ImplResponse{
 		Code: 200,

--- a/go-hello-world-service-7/internal/datastore/cockroach.go
+++ b/go-hello-world-service-7/internal/datastore/cockroach.go
@@ -151,6 +151,12 @@ func (c *Cockroach) GetItems(ctx context.Context, id string) (openapi.ImplRespon
 		}
 		list = append(list, i)
 	}
+	if len(list) == 0 {
+		return openapi.ImplResponse{
+			Code: 200,
+			Body: make([]string, 0),
+		}, nil
+	}
 	return openapi.ImplResponse{
 		Code: 200,
 		Body: list,
@@ -241,6 +247,12 @@ func (c *Cockroach) GetLanguages(ctx context.Context) (openapi.ImplResponse, err
 			return openapi.ImplResponse{}, err
 		}
 		list = append(list, i)
+	}
+	if len(list) == 0 {
+		return openapi.ImplResponse{
+			Code: 200,
+			Body: make([]string, 0),
+		}, nil
 	}
 	return openapi.ImplResponse{
 		Code: 200,


### PR DESCRIPTION
The following endpoints return null when there is no data but should return an empty collection []:

    GET /helloworld/api/v1/items
    GET /helloworld/api/v1/languages

This is user story is to update the following example to return an empty collection [] instead of null.
https://github.com/CiscoDevNet/msx-examples/tree/main/go-hello-world-service-5


Then propagate those changes forward in the future examples:

https://github.com/CiscoDevNet/msx-examples/tree/main/go-hello-world-service-6

https://github.com/CiscoDevNet/msx-examples/tree/main/go-hello-world-service-7


