### PR TITLE
US39980 private security client config for Python and Go examples.

### DIFF
--- a/go-hello-world-service-7/helloworld.yml
+++ b/go-hello-world-service-7/helloworld.yml
@@ -28,10 +28,10 @@ cockroach:
 swagger:
   secure: true                                # Required by MSX.
   ssourl: "http://localhost:9515/idm"         # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
-  clientid: "local-public-client"             # CONSUL {prefix}/helloworldservice/public.security.clientId
+  clientid:                                   # CONSUL {prefix}/helloworldservice/public.security.clientId
   swaggerjsonpath: "HelloWorldService-1.json" # Required by MSX.
 
 security:
-  ssourl: "http://localhost:9515/idm"                              # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
-  clientid: "local-private-client"                                 # CONSUL {prefix}/helloworldservice/integration.security.clientId
-  clientsecret: "make-up-a-private-client-secret-and-keep-it-safe" # Required by MSX.
+  ssourl: "http://localhost:9515/idm"          # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
+  clientid:                                    # CONSUL {prefix}/helloworldservice/integration.security.clientId
+  clientsecret:                                # Required by MSX.

--- a/go-hello-world-service-7/helloworld.yml
+++ b/go-hello-world-service-7/helloworld.yml
@@ -34,4 +34,4 @@ swagger:
 security:
   ssourl: "http://localhost:9515/idm"          # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
   clientid:                                    # CONSUL {prefix}/helloworldservice/integration.security.clientId
-  clientsecret:                                # Required by MSX.
+  clientsecret:                                # VAULT {prefix}/helloworldservice/integration.security.clientSecret

--- a/go-hello-world-service-7/manifest.yml
+++ b/go-hello-world-service-7/manifest.yml
@@ -26,16 +26,18 @@ ConsulKeys:
     Value: "Pizza"
   - Name: "favourite.dinosaur"
     Value: "Moros Intrepidus"
-  - Name: "public.security.clientId"
-    Value: "hello-world-service-public-client"
-  - Name: "integration.security.clientId"
-    Value: "hello-world-service-private-client"
+# NOT NEEDED FOR MSX >= 4.3
+#  - Name: "public.security.clientId"
+#    Value: "hello-world-service-public-client"
+#  - Name: "integration.security.clientId"
+#    Value: "hello-world-service-private-client"
 
 Secrets:
   - Name: "secret.squirrel.location"
     Value: "The acorns are buried under the big oak tree!"
-  - Name: "integration.security.clientSecret"
-    Value: "make-up-a-private-client-secret-and-keep-it-safe"
+# NOT NEEDED FOR MSX >= 4.3
+#  - Name: "integration.security.clientSecret"
+#    Value: "make-up-a-private-client-secret-and-keep-it-safe"
 
 Containers:
   - Name: "helloworldservice"

--- a/go-hello-world-service-8/helloworld.yml
+++ b/go-hello-world-service-8/helloworld.yml
@@ -28,10 +28,10 @@ cockroach:
 swagger:
   secure: true                                # Required by MSX.
   ssourl: "http://localhost:9515/idm"         # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
-  clientid: "local-public-client"             # CONSUL {prefix}/helloworldservice/public.security.clientId
+  clientid:                                   # CONSUL {prefix}/helloworldservice/public.security.clientId
   swaggerjsonpath: "HelloWorldService-1.json" # Required by MSX.
 
 security:
-  ssourl: "http://localhost:9515/idm"                              # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
-  clientid: "local-private-client"                                 # CONSUL {prefix}/helloworldservice/integration.security.clientId
-  clientsecret: "make-up-a-private-client-secret-and-keep-it-safe" # Required by MSX.
+  ssourl: "http://localhost:9515/idm" # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
+  clientid:                           # CONSUL {prefix}/helloworldservice/integration.security.clientId
+  clientsecret:                       # VAULT {prefix}/helloworldservice/integration.security.clientSecret

--- a/go-hello-world-service-8/internal/security/security.go
+++ b/go-hello-world-service-8/internal/security/security.go
@@ -30,6 +30,14 @@ func UpdateConfig(c *config.Config, consul *consul.HelloWorldConsul, vault *vaul
 	c.Security.SsoURL, _ = consul.GetString(c.Consul.Prefix+"/defaultapplication/swagger.security.sso.baseUrl", c.Security.SsoURL)
 	c.Security.ClientID, _ = consul.GetString(c.Consul.Prefix+"/helloworldservice/integration.security.clientId", c.Security.ClientID)
 	c.Security.ClientSecret, _ = vault.GetString(c.Vault.Prefix+"/helloworldservice", "integration.security.clientSecret", c.Security.ClientSecret)
+
+	// 20220524 - Temporary workaround for key issue.
+	if c.Security.ClientID == "" {
+		c.Security.ClientID, _ = consul.GetString(c.Consul.Prefix+"/helloworldservice/integration.security.client.clientId", c.Security.ClientID)
+	}
+	if c.Security.ClientSecret == "" {
+		c.Security.ClientSecret, _ = vault.GetString(c.Vault.Prefix+"/helloworldservice", "integration.security.client.clientSecret", c.Security.ClientSecret)
+	}
 	return nil
 }
 

--- a/go-hello-world-service-8/manifest.yml
+++ b/go-hello-world-service-8/manifest.yml
@@ -33,16 +33,18 @@ ConsulKeys:
     Value: "Pizza"
   - Name: "favourite.dinosaur"
     Value: "Moros Intrepidus"
-  - Name: "public.security.clientId"
-    Value: "hello-world-service-public-client"
-  - Name: "integration.security.clientId"
-    Value: "hello-world-service-private-client"
+# NOT NEEDED FOR MSX >= 4.3
+#  - Name: "public.security.clientId"
+#    Value: "hello-world-service-public-client"
+#  - Name: "integration.security.clientId"
+#    Value: "hello-world-service-private-client"
 
 Secrets:
   - Name: "secret.squirrel.location"
     Value: "The acorns are buried under the big oak tree!"
-  - Name: "integration.security.clientSecret"
-    Value: "make-up-a-private-client-secret-and-keep-it-safe"
+# NOT NEEDED FOR MSX >= 4.3
+#  - Name: "integration.security.clientSecret"
+#    Value: "make-up-a-private-client-secret-and-keep-it-safe"
 
 Containers:
   - Name: "helloworldservice"

--- a/python-hello-world-service-7/helloworld.yml
+++ b/python-hello-world-service-7/helloworld.yml
@@ -26,12 +26,12 @@ swagger:
   rootpath: "/helloworld"             # Required by MSX.
   secure: true                        # Required by MSX.
   ssourl: "http://localhost:9515/idm" # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
-  clientid: "local-public-client"     # CONSUL {prefix}/helloworldservice/public.security.clientId
+  clientid:                           # CONSUL {prefix}/helloworldservice/public.security.clientId
   swaggerjsonpath: "swagger.json"     # Required by MSX.
 
 security:
-  ssourl: "http://localhost:9515/idm"                              # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
-  clientid: "local-private-client"                                 # CONSUL {prefix}/helloworldservice/integration.security.clientId
-  clientsecret: "make-up-a-private-client-secret-and-keep-it-safe" # Required by MSX.
+  ssourl: "http://localhost:9515/idm" # CONSUL {prefix}/defaultapplication/swagger.security.sso.baseUrl
+  clientid:                           # CONSUL {prefix}/helloworldservice/integration.security.clientId
+  clientsecret:                       # VAULT {prefix}/helloworldservice/integration.security.clientSecret
   sslverify: false
   

--- a/python-hello-world-service-7/helpers/security_helper.py
+++ b/python-hello-world-service-7/helpers/security_helper.py
@@ -3,7 +3,6 @@
 # All rights reserved
 #
 from msxsecurity import MSXSecurityConfig
-
 from config import Config
 from helpers.consul_helper import ConsulHelper
 from helpers.vault_helper import VaultHelper
@@ -30,6 +29,17 @@ class SecurityHelper(object):
             secret=f"{self._config.config_prefix}/helloworldservice",
             key="integration.security.sslVerify",
             default=self._config.security.sslverify)
+
+        # 20220524 - Temporary workaround for key issue.
+        if not client_id:
+            client_id = self._consul_helper.get_string(
+                key=f"{self._config.config_prefix}/helloworldservice/integration.security.client.clientId",
+                default=self._config.security.clientid)
+        if not client_secret:
+            client_secret = self._vault_helper.get_string(
+                secret=f"{self._config.config_prefix}/helloworldservice",
+                key="integration.security.client.clientSecret",
+                default=self._config.security.clientsecret)
 
         return MSXSecurityConfig(
             sso_url=sso_url,

--- a/python-hello-world-service-7/manifest.yml
+++ b/python-hello-world-service-7/manifest.yml
@@ -53,16 +53,18 @@ ConsulKeys:
     Value: "Pizza"
   - Name: "favourite.dinosaur"
     Value: "Moros Intrepidus"
-  - Name: "public.security.clientId"
-    Value: "hello-world-service-public-client"
-  - Name: "integration.security.clientId"
-    Value: "hello-world-service-private-client"
+# NOT NEEDED FOR MSX >= 4.3
+#  - Name: "public.security.clientId"
+#    Value: "hello-world-service-public-client"
+#  - Name: "integration.security.clientId"
+#    Value: "hello-world-service-private-client"
 
 Secrets:
   - Name: "secret.squirrel.location"
     Value: "The acorns are buried under the big oak tree!"
-  - Name: "integration.security.clientSecret"
-    Value: "make-up-a-private-client-secret-and-keep-it-safe"
+# NOT NEEDED FOR MSX >= 4.3
+#  - Name: "integration.security.clientSecret"
+#    Value: "make-up-a-private-client-secret-and-keep-it-safe"
 
 Infrastructure:
   Database:


### PR DESCRIPTION
US39980 private security client config for Python and Go examples.

There were an accidental key changes for the Consul/Vault config for the private security client in the  MSX 4.3 release. These changes are a workaround for the current Python and Go examples so they work on MSX 4.2 and 4.3 from the same build.